### PR TITLE
Use `mock` from standard library

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,3 @@
 pytest
 pytest-cov
 pytest-xdist
-mock

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,10 +1,8 @@
-from __future__ import unicode_literals
-
 import hashlib
 import textwrap
 from io import BytesIO
+from unittest import mock
 
-import mock
 import pytest
 
 from installer import install


### PR DESCRIPTION
I assume that `mock` from PyPI was only used because of Python 2 support. We should now be able to use stdlib instead :smiley_cat: 