### PR TITLE
Modernize with `pyupgrade --py37-plus`

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -46,11 +46,11 @@ def test(session):
         "--cov=installer",
         "--cov-fail-under=100",
         "--cov-report=term-missing",
-        "--cov-report=html:{}".format(htmlcov_output),
+        f"--cov-report=html:{htmlcov_output}",
         "--cov-context=test",
         "-n",
         "auto",
-        *session.posargs
+        *session.posargs,
     )
 
 

--- a/src/installer/_core.py
+++ b/src/installer/_core.py
@@ -18,7 +18,7 @@ def _process_WHEEL_file(source: WheelSource) -> Scheme:
 
     Returns the scheme that the archive root should go in.
     """
-    stream = source.read_dist_info(u"WHEEL")
+    stream = source.read_dist_info("WHEEL")
     metadata = parse_metadata_file(stream)
 
     # Ensure compatibility with this wheel version.
@@ -55,7 +55,7 @@ def _determine_scheme(
             break
 
     if scheme_name not in SCHEME_NAMES:
-        msg_fmt = u"{path} is not contained in a valid .data subdirectory."
+        msg_fmt = "{path} is not contained in a valid .data subdirectory."
         raise InvalidWheelSource(source, msg_fmt.format(path=path))
 
     return cast(Scheme, scheme_name), posixpath.join(*reversed(parts[:-1]))
@@ -77,7 +77,7 @@ def install(
     root_scheme = _process_WHEEL_file(source)
 
     # RECORD handling
-    record_file_path = posixpath.join(source.dist_info_dir, u"RECORD")
+    record_file_path = posixpath.join(source.dist_info_dir, "RECORD")
     written_records = []
 
     # Write the entry_points based scripts.

--- a/src/installer/destinations.py
+++ b/src/installer/destinations.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
     from installer.scripts import LauncherKind, ScriptSection
 
 
-class WheelDestination(object):
+class WheelDestination:
     """Handles writing the unpacked files, script generation and ``RECORD`` generation.
 
     Subclasses provide the concrete script generation logic, as well as the RECORD file
@@ -120,7 +120,7 @@ class SchemeDictionaryDestination(WheelDestination):
         """
         target_path = os.path.join(self.scheme_dict[scheme], path)
         if os.path.exists(target_path):
-            message = "File already exists: {}".format(target_path)
+            message = f"File already exists: {target_path}"
             raise FileExistsError(message)
 
         parent_folder = os.path.dirname(target_path)

--- a/src/installer/records.py
+++ b/src/installer/records.py
@@ -17,7 +17,7 @@ class InvalidRecordEntry(Exception):
     """Raised when a RecordEntry is not valid, due to improper element values or count."""
 
     def __init__(self, elements, issues):  # noqa: D107
-        super(InvalidRecordEntry, self).__init__(", ".join(issues))
+        super().__init__(", ".join(issues))
         self.issues = issues
         self.elements = elements
 
@@ -27,7 +27,7 @@ class InvalidRecordEntry(Exception):
         )
 
 
-class Hash(object):
+class Hash:
     """Represents the "hash" element of a RecordEntry."""
 
     def __init__(self, name: str, value: str) -> None:
@@ -43,10 +43,10 @@ class Hash(object):
         self.value = value
 
     def __str__(self) -> str:
-        return "{}={}".format(self.name, self.value)
+        return f"{self.name}={self.value}"
 
     def __repr__(self) -> str:
-        return "Hash(name={!r}, value={!r})".format(self.name, self.value)
+        return f"Hash(name={self.name!r}, value={self.value!r})"
 
     def __eq__(self, other):
         if not isinstance(other, Hash):
@@ -80,7 +80,7 @@ class Hash(object):
         return cls(name, value)
 
 
-class RecordEntry(object):
+class RecordEntry:
     """Represents a single record in a RECORD file.
 
     A list of :py:class:`RecordEntry` objects fully represents a RECORD file.
@@ -96,7 +96,7 @@ class RecordEntry(object):
         :param hash\_: hash of the file's contents
         :param size: file's size in bytes
         """
-        super(RecordEntry, self).__init__()
+        super().__init__()
 
         self.path = path
         self.hash_ = hash_

--- a/src/installer/scripts.py
+++ b/src/installer/scripts.py
@@ -79,7 +79,7 @@ class InvalidScript(ValueError):
     """Raised if the user provides incorrect script section or kind."""
 
 
-class Script(object):
+class Script:
     """Describes a script based on an entry point declaration."""
 
     __slots__ = ("name", "module", "attr", "section")
@@ -116,7 +116,7 @@ class Script(object):
         try:
             name = _ALLOWED_LAUNCHERS[key]
         except KeyError:
-            error = "{!r} not in {!r}".format(key, sorted(_ALLOWED_LAUNCHERS))
+            error = f"{key!r} not in {sorted(_ALLOWED_LAUNCHERS)!r}"
             raise InvalidScript(error)
         return read_binary(_scripts, name)
 
@@ -146,6 +146,6 @@ class Script(object):
         stream = io.BytesIO()
         with zipfile.ZipFile(stream, "w") as zf:
             zf.writestr("__main__.py", code)
-        name = "{}.exe".format(self.name)
+        name = f"{self.name}.exe"
         data = launcher + shebang + b"\n" + stream.getvalue()
         return (name, data)

--- a/src/installer/sources.py
+++ b/src/installer/sources.py
@@ -15,7 +15,7 @@ WheelContentElement = Tuple[Tuple[str, str, str], BinaryIO]
 __all__ = ["WheelSource", "WheelFile"]
 
 
-class WheelSource(object):
+class WheelSource:
     """Represents an installable wheel.
 
     This is an abstract class, whose methods have to be implemented by subclasses.
@@ -27,19 +27,19 @@ class WheelSource(object):
         :param distribution: distribution name (like ``urllib3``)
         :param version: version associated with the wheel
         """
-        super(WheelSource, self).__init__()
+        super().__init__()
         self.distribution = distribution
         self.version = version
 
     @property
     def dist_info_dir(self):
         """Name of the dist-info directory."""
-        return u"{}-{}.dist-info".format(self.distribution, self.version)
+        return f"{self.distribution}-{self.version}.dist-info"
 
     @property
     def data_dir(self):
         """Name of the data directory."""
-        return u"{}-{}.data".format(self.distribution, self.version)
+        return f"{self.distribution}-{self.version}.data"
 
     @property
     def dist_info_filenames(self) -> List[str]:
@@ -108,7 +108,7 @@ class WheelFile(WheelSource):
 
         basename = os.path.basename(f.filename)
         parsed_name = installer.utils.parse_wheel_filename(basename)
-        super(WheelFile, self).__init__(
+        super().__init__(
             version=parsed_name.version,
             distribution=parsed_name.distribution,
         )

--- a/src/installer/utils.py
+++ b/src/installer/utils.py
@@ -97,7 +97,7 @@ def parse_wheel_filename(filename: str) -> WheelFilename:
     """
     wheel_info = _WHEEL_FILENAME_REGEX.match(filename)
     if not wheel_info:
-        raise ValueError("Not a valid wheel filename: {}".format(filename))
+        raise ValueError(f"Not a valid wheel filename: {filename}")
     return WheelFilename(*wheel_info.groups())
 
 
@@ -160,7 +160,7 @@ def fix_shebang(stream: BinaryIO, interpreter: str) -> Iterator[BinaryIO]:
     if stream.read(8) == b"#!python":
         new_stream = io.BytesIO()
         # write our new shebang
-        new_stream.write("#!{}\n".format(interpreter).encode())
+        new_stream.write(f"#!{interpreter}\n".encode())
         # copy the rest of the stream
         stream.seek(0)
         stream.readline()  # skip first line

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -38,7 +38,7 @@ def mock_destination():
 
 class FakeWheelSource(WheelSource):
     def __init__(self, *, distribution, version, regular_files, dist_info_files):
-        super(FakeWheelSource, self).__init__(distribution, version)
+        super().__init__(distribution, version)
 
         self.dist_info_files = {
             file: textwrap.dedent(content.decode("utf-8"))
@@ -70,7 +70,7 @@ class FakeWheelSource(WheelSource):
         # insertion order for dictionaries.
         for file, content in sorted(self.regular_files.items()):
             hashed, size = hash_and_size(content)
-            record = (file, "sha256={}".format(hashed), str(size))
+            record = (file, f"sha256={hashed}", str(size))
             with BytesIO(content) as stream:
                 yield record, stream
 
@@ -81,7 +81,7 @@ class FakeWheelSource(WheelSource):
             hashed, size = hash_and_size(content)
             record = (
                 self.dist_info_dir + "/" + file,
-                "sha256={}".format(hashed),
+                f"sha256={hashed}",
                 str(size),
             )
             with BytesIO(content) as stream:

--- a/tests/test_records.py
+++ b/tests/test_records.py
@@ -241,7 +241,7 @@ class TestParseRecordFile:
         with pytest.raises(InvalidRecordEntry) as exc_info:
             list(parse_record_file([line]))
 
-        message = "expected 3 elements, got {}".format(element_count)
+        message = f"expected 3 elements, got {element_count}"
         assert message in str(exc_info.value)
 
     def test_shows_correct_row_number(self):

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -34,7 +34,7 @@ def _read_launcher_data(section, kind):
     suffix = {"win-ia32": "32", "win-amd64": "64", "win-arm": "_arm"}[kind]
     filename = os.path.join(
         os.path.dirname(os.path.abspath(_scripts.__file__)),
-        "{}{}.exe".format(prefix, suffix),
+        f"{prefix}{suffix}.exe",
     )
     with open(filename, "rb") as f:
         return f.read()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -93,7 +93,7 @@ class TestParseWheelFilename:
             parse_wheel_filename(string)
 
 
-class TestCopyFileObjWithHashing(object):
+class TestCopyFileObjWithHashing:
     def test_basic_functionality(self):
         data = b"input data is this"
         hash_ = hashlib.sha256(data).hexdigest()
@@ -177,9 +177,9 @@ class TestParseEntryPoints:
     @pytest.mark.parametrize(
         ("script", "expected"),
         [
-            pytest.param(u"", [], id="empty"),
+            pytest.param("", [], id="empty"),
             pytest.param(
-                u"""
+                """
                     [foo]
                     foo = foo.bar
                 """,
@@ -187,7 +187,7 @@ class TestParseEntryPoints:
                 id="unrelated",
             ),
             pytest.param(
-                u"""
+                """
                     [console_scripts]
                     package = package.__main__:package
                 """,
@@ -197,7 +197,7 @@ class TestParseEntryPoints:
                 id="cli",
             ),
             pytest.param(
-                u"""
+                """
                     [gui_scripts]
                     package = package.__main__:package
                 """,
@@ -207,7 +207,7 @@ class TestParseEntryPoints:
                 id="gui",
             ),
             pytest.param(
-                u"""
+                """
                     [console_scripts]
                     magic-cli = magic.cli:main
 


### PR DESCRIPTION
This PR was made by temporarily adding the following pre-commit hook and then executing `pre-commit run -a`

```yaml
- repo: https://github.com/asottile/pyupgrade
    rev: v2.29.0
    hooks:
      - id: pyupgrade
        args: [--py37-plus]
```

This automates some modernizations like removal of u-strings and the legacy super syntax.