### PR TITLE
Implement `--prefix` option

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,3 +1,5 @@
+import os
+
 from installer.__main__ import _get_scheme_dict as get_scheme_dict
 from installer.__main__ import _main as main
 
@@ -7,6 +9,14 @@ def test_get_scheme_dict():
     assert set(d.keys()) >= {"purelib", "platlib", "headers", "scripts", "data"}
 
 
+def test_get_scheme_dict_prefix():
+    d = get_scheme_dict(distribution_name="foo", prefix="/foo")
+    for key in ("purelib", "platlib", "headers", "scripts", "data"):
+        assert d[key].startswith(
+            f"{os.sep}foo"
+        ), f"{key} does not start with /foo: {d[key]}"
+
+
 def test_main(fancy_wheel, tmp_path):
     destdir = tmp_path / "dest"
 
@@ -14,6 +24,26 @@ def test_main(fancy_wheel, tmp_path):
 
     installed_py_files = destdir.rglob("*.py")
 
+    assert {f.stem for f in installed_py_files} == {"__init__", "__main__", "data"}
+
+    installed_pyc_files = destdir.rglob("*.pyc")
+    assert {f.name.split(".")[0] for f in installed_pyc_files} == {
+        "__init__",
+        "__main__",
+    }
+
+
+def test_main_prefix(fancy_wheel, tmp_path):
+    destdir = tmp_path / "dest"
+
+    main([str(fancy_wheel), "-d", str(destdir), "-p", "/foo"], "python -m installer")
+
+    installed_py_files = list(destdir.rglob("*.py"))
+
+    for f in installed_py_files:
+        assert str(f.parent).startswith(
+            str(destdir / "foo")
+        ), f"path does not respect destdir+prefix: {f}"
     assert {f.stem for f in installed_py_files} == {"__init__", "__main__", "data"}
 
     installed_pyc_files = destdir.rglob("*.pyc")


### PR DESCRIPTION
Implement a --prefix option that can be used to override platbase
and base when expanding the paths from install scheme.  This can be used
to install paths to a layout using another prefix than the one used
to run installer.

Gentoo use case for this is running installer inside a venv to prepare
installation images for the real system.  The nixOS maintainers have
also indicated interest in this feature.

Fixes #98