### PR TITLE
Construct RECORD file using csv.writer

### DIFF
--- a/src/installer/records.py
+++ b/src/installer/records.py
@@ -103,11 +103,11 @@ class RecordEntry:
         self.hash_ = hash_
         self.size = size
 
-    def to_line(self, path_prefix: Optional[str] = None) -> bytes:
-        """Convert this into a line that can be written in a RECORD file.
+    def to_row(self, path_prefix: Optional[str] = None) -> Tuple[str, str, str]:
+        """Convert this into a 3-element tuple that can be written in a RECORD file.
 
         :param path_prefix: A prefix to attach to the path -- must end in `/`
-        :return: A binary-encoded line, that doesn't contain a newline
+        :return: a (path, hash, size) row
         """
         if path_prefix is not None:
             assert path_prefix.endswith("/")
@@ -119,13 +119,11 @@ class RecordEntry:
         if os.sep == "\\":
             path = path.replace("\\", "/")  # pragma: no cover
 
-        entry = ",".join(
-            [
-                (str(elem) if elem is not None else "")
-                for elem in [path, self.hash_, self.size]
-            ]
+        return (
+            path,
+            str(self.hash_ or ""),
+            str(self.size) if self.size is not None else "",
         )
-        return entry.encode("utf-8")
 
     def __repr__(self) -> str:
         return "RecordEntry(path={!r}, hash_={!r}, size={!r})".format(

--- a/src/installer/utils.py
+++ b/src/installer/utils.py
@@ -1,6 +1,7 @@
 """Utilities related to handling / interacting with wheel files."""
 
 import contextlib
+import csv
 import hashlib
 import io
 import os
@@ -192,11 +193,13 @@ def construct_record_file(
 
     :return: A stream that can be written to file. Must be closed by the caller.
     """
-    stream = io.BytesIO()
+
+    stream = io.TextIOWrapper(io.BytesIO(), encoding="utf-8", write_through=True)
+    writer = csv.writer(stream, delimiter=",", quotechar='"', lineterminator="\n")
     for scheme, record in records:
-        stream.write(record.to_line(prefix_for_scheme(scheme)) + b"\n")
+        writer.writerow(record.to_row(prefix_for_scheme(scheme)))
     stream.seek(0)
-    return stream
+    return stream.detach()
 
 
 def parse_entrypoints(text: str) -> Iterable[Tuple[str, str, str, "ScriptSection"]]:

--- a/src/installer/utils.py
+++ b/src/installer/utils.py
@@ -193,7 +193,6 @@ def construct_record_file(
 
     :return: A stream that can be written to file. Must be closed by the caller.
     """
-
     stream = io.TextIOWrapper(io.BytesIO(), encoding="utf-8", write_through=True)
     writer = csv.writer(stream, delimiter=",", quotechar='"', lineterminator="\n")
     for scheme, record in records:

--- a/src/installer/utils.py
+++ b/src/installer/utils.py
@@ -193,7 +193,9 @@ def construct_record_file(
 
     :return: A stream that can be written to file. Must be closed by the caller.
     """
-    stream = io.TextIOWrapper(io.BytesIO(), encoding="utf-8", write_through=True)
+    stream = io.TextIOWrapper(
+        io.BytesIO(), encoding="utf-8", write_through=True, newline=""
+    )
     writer = csv.writer(stream, delimiter=",", quotechar='"', lineterminator="\n")
     for scheme, record in records:
         writer.writerow(record.to_row(prefix_for_scheme(scheme)))

--- a/tests/test_destinations.py
+++ b/tests/test_destinations.py
@@ -124,7 +124,7 @@ class TestSchemeDictionaryDestination:
                 "data",
                 destination.write_file(
                     "data",
-                    "my_data3.bin",
+                    "my_data3,my_data4.bin",
                     io.BytesIO(b"my data 3"),
                     is_executable=False,
                 ),
@@ -165,7 +165,7 @@ class TestSchemeDictionaryDestination:
         assert data == (
             b"../data/my_data1.bin,sha256=355d00f8ce0e3eea93b078de0fa5ad87ff94aaba40000772a6572eb2d159f2ce,9\n"
             b"../data/my_data2.bin,sha256=94fed5f2858baa0c9709b74048d88f76c5288333d466186dffb17c4f96c2dde4,9\n"
-            b"../data/my_data3.bin,sha256=d7c92baeebb582bd35c7e58cffd0a14804a81efd267d1015ebe0766ddf6cc69a,9\n"
+            b'"../data/my_data3,my_data4.bin",sha256=d7c92baeebb582bd35c7e58cffd0a14804a81efd267d1015ebe0766ddf6cc69a,9\n'
             b"../scripts/my_script,sha256=33ad1f5af51230990fb70d9aa54be3596c0e72744f715cbfccee3ee25a47d3ca,9\n"
             b"../scripts/my_script2,sha256=93dffdf7b9136d36109bb11714b7255592f59b637df2b53dd105f8e9778cbe36,22\n"
             b"../scripts/my_entrypoint,sha256=fe9ffd9f099e21ea0c05f4346a486bd4a6ca9f795a0f2760d09edccb416ce892,216\n"


### PR DESCRIPTION
To correctly quote paths in the record entry.

Fix #117