### PR TITLE
Normalize wheel filenames

### DIFF
--- a/src/installer/utils.py
+++ b/src/installer/utils.py
@@ -109,7 +109,9 @@ def parse_wheel_filename(filename: str) -> WheelFilename:
     wheel_info = _WHEEL_FILENAME_REGEX.match(filename)
     if not wheel_info:
         raise ValueError(f"Not a valid wheel filename: {filename}")
-    return WheelFilename(*wheel_info.groups())
+    parsed = wheel_info.groups()
+    normalized_name = normalize_distribution_name(parsed[0])
+    return WheelFilename(normalized_name, *parsed[1:])
 
 
 def copyfileobj_with_hashing(

--- a/src/installer/utils.py
+++ b/src/installer/utils.py
@@ -93,6 +93,14 @@ def parse_metadata_file(contents: str) -> Message:
     return feed_parser.close()
 
 
+def normalize_distribution_name(name: str) -> str:
+    """Normalize a project name according to PEP-503.
+
+    :param name: The project name to normalize
+    """
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
 def parse_wheel_filename(filename: str) -> WheelFilename:
     """Parse a wheel filename, into it's various components.
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -93,6 +93,11 @@ class TestParseWheelFilename:
                 "tensorflow-2.3.0-cp38-cp38-win_amd64.whl",
                 WheelFilename("tensorflow", "2.3.0", None, "cp38-cp38-win_amd64"),
             ),
+            # Non-canonicalized real wheel names
+            (
+                "Quart-0.18.0-py3-none-any.whl",
+                WheelFilename("quart", "0.18.0", None, "py3-none-any"),
+            ),
         ],
     )
     def test_valid_cases(self, string, expected):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -15,6 +15,7 @@ from installer.utils import (
     construct_record_file,
     copyfileobj_with_hashing,
     fix_shebang,
+    normalize_distribution_name,
     parse_entrypoints,
     parse_metadata_file,
     parse_wheel_filename,
@@ -38,6 +39,27 @@ class TestParseMetadata:
         assert result.get("Name") == "package"
         assert result.get("version") == "1.0.0"
         assert result.get_all("MULTI-USE-FIELD") == ["1", "2", "3"]
+
+
+class TestNormalizeDistributionName:
+    @pytest.mark.parametrize(
+        "string, expected",
+        [
+            # Noop
+            (
+                "package-1",
+                "package-1",
+            ),
+            # PEP 508 normalization
+            (
+                "ABC..12",
+                "abc-12",
+            ),
+        ],
+    )
+    def test_valid_cases(self, string, expected):
+        got = normalize_distribution_name(string)
+        assert expected == got, (expected, got)
 
 
 class TestParseWheelFilename:


### PR DESCRIPTION
This is a fairly simple solution to #134, without any refactoring needed to close #97.

There are other places this normalization could be done, but this seems like the logical place to do it. It does mean that you can't get back from a `WheelFilename` object to the filename on disk, but that doesn't seem very important.

Fixes: #134