### PR TITLE
Search wheels for `.dist-info` directories

### DIFF
--- a/src/installer/sources.py
+++ b/src/installer/sources.py
@@ -8,7 +8,7 @@ from contextlib import contextmanager
 from typing import BinaryIO, ClassVar, Iterator, List, Tuple, Type, cast
 
 from installer.records import RecordEntry, parse_record_file
-from installer.utils import parse_wheel_filename
+from installer.utils import canonicalize_name, parse_wheel_filename
 
 WheelContentElement = Tuple[Tuple[str, str, str], BinaryIO, bool]
 
@@ -155,10 +155,21 @@ class WheelFile(WheelSource):
             dist_infos = [
                 name for name in top_level_directories if name.endswith(".dist-info")
             ]
+
             assert (
                 len(dist_infos) == 1
             ), "Wheel doesn't contain exactly one .dist-info directory"
-            self._dist_info_dir = dist_infos[0]
+            dist_info_dir = dist_infos[0]
+
+            # NAME-VER.dist-info
+            di_dname = dist_info_dir.rsplit("-", 2)[0]
+            norm_di_dname = canonicalize_name(di_dname)
+            norm_file_dname = canonicalize_name(self.distribution)
+            assert (
+                norm_di_dname == norm_file_dname
+            ), "Wheel .dist-info directory doesn't match wheel filename"
+
+            self._dist_info_dir = dist_info_dir
         return self._dist_info_dir
 
     @property

--- a/src/installer/sources.py
+++ b/src/installer/sources.py
@@ -146,6 +146,22 @@ class WheelFile(WheelSource):
             yield cls(f)
 
     @property
+    def dist_info_dir(self) -> str:
+        """Name of the dist-info directory."""
+        if not hasattr(self, "_dist_info_dir"):
+            top_level_directories = {
+                path.split("/", 1)[0] for path in self._zipfile.namelist()
+            }
+            dist_infos = [
+                name for name in top_level_directories if name.endswith(".dist-info")
+            ]
+            assert (
+                len(dist_infos) == 1
+            ), "Wheel doesn't contain exactly one .dist-info directory"
+            self._dist_info_dir = dist_infos[0]
+        return self._dist_info_dir
+
+    @property
     def dist_info_filenames(self) -> List[str]:
         """Get names of all files in the dist-info directory."""
         base = self.dist_info_dir

--- a/src/installer/utils.py
+++ b/src/installer/utils.py
@@ -94,6 +94,14 @@ def parse_metadata_file(contents: str) -> Message:
     return feed_parser.close()
 
 
+def canonicalize_name(name: str) -> str:
+    """Canonicalize a project name according to PEP-503.
+
+    :param name: The project name to canonicalize
+    """
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
 def parse_wheel_filename(filename: str) -> WheelFilename:
     """Parse a wheel filename, into it's various components.
 

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -104,6 +104,14 @@ class TestWheelFile:
         with WheelFile.open(denorm) as source:
             assert source.dist_info_filenames
 
+    def test_requires_dist_info_name_match(self, fancy_wheel):
+        misnamed = fancy_wheel.rename(
+            fancy_wheel.parent / "misnamed-1.0.0-py3-none-any.whl"
+        )
+        with pytest.raises(AssertionError):
+            with WheelFile.open(misnamed) as source:
+                source.dist_info_filenames
+
 
 def replace_file_in_zip(path: str, filename: str, content: "bytes | None") -> None:
     """Helper function for replacing a file in the zip.

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -99,6 +99,11 @@ class TestWheelFile:
         assert sorted(got_records) == sorted(expected_records)
         assert got_files == files
 
+    def test_finds_dist_info(self, fancy_wheel):
+        denorm = fancy_wheel.rename(fancy_wheel.parent / "Fancy-1.0.0-py3-none-any.whl")
+        with WheelFile.open(denorm) as source:
+            assert source.dist_info_filenames
+
 
 def replace_file_in_zip(path: str, filename: str, content: "bytes | None") -> None:
     """Helper function for replacing a file in the zip.

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -101,6 +101,8 @@ class TestWheelFile:
 
     def test_finds_dist_info(self, fancy_wheel):
         denorm = fancy_wheel.rename(fancy_wheel.parent / "Fancy-1.0.0-py3-none-any.whl")
+        # Python 3.7: rename doesn't return the new name:
+        denorm = fancy_wheel.parent / "Fancy-1.0.0-py3-none-any.whl"
         with WheelFile.open(denorm) as source:
             assert source.dist_info_filenames
 
@@ -108,6 +110,8 @@ class TestWheelFile:
         misnamed = fancy_wheel.rename(
             fancy_wheel.parent / "misnamed-1.0.0-py3-none-any.whl"
         )
+        # Python 3.7: rename doesn't return the new name:
+        misnamed = fancy_wheel.parent / "misnamed-1.0.0-py3-none-any.whl"
         with pytest.raises(AssertionError):
             with WheelFile.open(misnamed) as source:
                 source.dist_info_filenames

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -16,6 +16,7 @@ from installer.utils import (
     construct_record_file,
     copyfileobj_with_hashing,
     fix_shebang,
+    canonicalize_name,
     parse_entrypoints,
     parse_metadata_file,
     parse_wheel_filename,
@@ -39,6 +40,27 @@ class TestParseMetadata:
         assert result.get("Name") == "package"
         assert result.get("version") == "1.0.0"
         assert result.get_all("MULTI-USE-FIELD") == ["1", "2", "3"]
+
+
+class TestCanonicalizeDistributionName:
+    @pytest.mark.parametrize(
+        "string, expected",
+        [
+            # Noop
+            (
+                "package-1",
+                "package-1",
+            ),
+            # PEP 508 canonicalization
+            (
+                "ABC..12",
+                "abc-12",
+            ),
+        ],
+    )
+    def test_valid_cases(self, string, expected):
+        got = canonicalize_name(string)
+        assert expected == got, (expected, got)
 
 
 class TestParseWheelFilename:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -13,10 +13,10 @@ from test_records import SAMPLE_RECORDS
 from installer.records import RecordEntry
 from installer.utils import (
     WheelFilename,
+    canonicalize_name,
     construct_record_file,
     copyfileobj_with_hashing,
     fix_shebang,
-    canonicalize_name,
     parse_entrypoints,
     parse_metadata_file,
     parse_wheel_filename,


### PR DESCRIPTION
Some wheels don't use normalized names for their `.dist-info` directories, so search the wheel for them.

Fixes: #134