### PR TITLE
add --scheme argument

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -17,6 +17,19 @@ def test_get_scheme_dict_prefix():
         ), f"{key} does not start with /foo: {d[key]}"
 
 
+def test_get_scheme_dict_prefix_scheme():
+    d = get_scheme_dict(distribution_name="foo", prefix="/foo", scheme="posix_prefix")
+    for key in ("purelib", "platlib", "headers", "scripts", "data"):
+        assert d[key].startswith(
+            f"{os.sep}foo"
+        ), f"{key} does not start with /foo: {d[key]}"
+
+
+def test_get_scheme_dict_scheme():
+    d = get_scheme_dict(distribution_name="foo", scheme="posix_prefix")
+    assert set(d.keys()) >= {"purelib", "platlib", "headers", "scripts", "data"}
+
+
 def test_main(fancy_wheel, tmp_path):
     destdir = tmp_path / "dest"
 


### PR DESCRIPTION
solves #120

This adds a new optional argument, `--scheme`, that will force the installation to be done using a specific scheme instead of the default one.

example usage:
```
python -m installer --scheme posix_user some.whl
```

see https://docs.python.org/3/library/sysconfig.html?highlight=installation%20scheme#installation-paths
for a list of valid schemes