### PR TITLE
Add support for Python 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,10 +27,10 @@ jobs:
             python-version: pypy-3.7
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       # Get Python to test against
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -42,7 +42,7 @@ jobs:
         id: pip-cache-dir
         run: echo "::set-output name=dir::$(pip cache dir)"
       - name: pip cache
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ${{ steps.pip-cache-dir.outputs.dir }}
           key: pip-v1-${{ runner.os }}-${{ steps.date.outputs.date }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         os: [Windows, Ubuntu, MacOS]
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         include:
           # Only run PyPy jobs, on Ubuntu.
           - os: Ubuntu

--- a/noxfile.py
+++ b/noxfile.py
@@ -20,7 +20,7 @@ def _install_this_project_with_flit(session, *, extras=None, editable=False):
     session.run("flit", "install", "--deps=production", *args, silent=True)
 
 
-@nox.session(python="3.8")
+@nox.session(python="3.11")
 def lint(session):
     session.install("pre-commit")
 
@@ -34,7 +34,7 @@ def lint(session):
     session.run("pre-commit", "run", "--all-files", *args)
 
 
-@nox.session(python=["3.7", "3.8", "3.9", "3.10", "pypy3"])
+@nox.session(python=["3.7", "3.8", "3.9", "3.10", "3.11", "pypy3"])
 def test(session):
     _install_this_project_with_flit(session, editable=True)
     session.install("-r", "tests/requirements.txt")
@@ -54,7 +54,7 @@ def test(session):
     )
 
 
-@nox.session(python=["3.7", "3.8", "3.9", "3.10", "pypy3"])
+@nox.session(python=["3.7", "3.8", "3.9", "3.10", "3.11", "pypy3"])
 def doctest(session):
     session.install(".")
     session.install("-r", "docs/requirements.txt")
@@ -62,7 +62,7 @@ def doctest(session):
     session.run("sphinx-build", "-b", "doctest", "docs/", "build/doctest")
 
 
-@nox.session(python="3.8", name="update-launchers")
+@nox.session(python="3.11", name="update-launchers")
 def update_launchers(session):
     session.install("httpx")
     session.run("python", "tools/update_launchers.py")
@@ -71,7 +71,7 @@ def update_launchers(session):
 #
 # Documentation
 #
-@nox.session(python="3.8")
+@nox.session(python="3.11")
 def docs(session):
     _install_this_project_with_flit(session)
     session.install("-r", "docs/requirements.txt")
@@ -80,7 +80,7 @@ def docs(session):
     session.run("sphinx-build", "-W", "-b", "html", "docs/", "build/docs")
 
 
-@nox.session(name="docs-live", python="3.8")
+@nox.session(name="docs-live", python="3.11")
 def docs_live(session):
     _install_this_project_with_flit(session, editable=True)
     session.install("-r", "docs/requirements.txt")


### PR DESCRIPTION
Python 3.11 was [released on 2022-10-24](https://discuss.python.org/t/python-3-11-0-final-is-now-available/20291?u=hugovk) 🚀 

[![image](https://user-images.githubusercontent.com/1324225/198233993-5b79523b-370f-4316-a4be-9403c8209068.png)](https://discuss.python.org/t/python-3-11-0-final-is-now-available/20291?u=hugovk)
