### PR TITLE
Add `--validate-record` to CLI

### DIFF
--- a/src/installer/__main__.py
+++ b/src/installer/__main__.py
@@ -43,6 +43,14 @@ def _get_main_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="don't generate bytecode for installed modules",
     )
+    parser.add_argument(
+        "--validate-record",
+        metavar="part",
+        default="none",
+        type=str,
+        choices=["all", "entries", "none"],
+        help="validate the wheel against certain part of its record (default=none)",
+    )
     return parser
 
 
@@ -84,6 +92,8 @@ def _main(cli_args: Sequence[str], program: Optional[str] = None) -> None:
         bytecode_levels = [0, 1]
 
     with WheelFile.open(args.wheel) as source:
+        if args.validate_record != "none":
+            source.validate_record(args.validate_record == "all")
         destination = SchemeDictionaryDestination(
             scheme_dict=_get_scheme_dict(source.distribution, prefix=args.prefix),
             interpreter=sys.executable,

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,5 +1,7 @@
 import os
 
+import pytest
+
 from installer.__main__ import _get_scheme_dict as get_scheme_dict
 from installer.__main__ import _main as main
 
@@ -67,3 +69,26 @@ def test_main_no_pyc(fancy_wheel, tmp_path):
 
     installed_pyc_files = destdir.rglob("*.pyc")
     assert set(installed_pyc_files) == set()
+
+
+@pytest.mark.parametrize(
+    "validation_part",
+    ["all", "entries", "none"],
+)
+def test_main_validate_record_all_pass(fancy_wheel, tmp_path, validation_part):
+    destdir = tmp_path / "dest"
+
+    main(
+        [str(fancy_wheel), "-d", str(destdir), "--validate-record", validation_part],
+        "python -m installer",
+    )
+
+    installed_py_files = destdir.rglob("*.py")
+
+    assert {f.stem for f in installed_py_files} == {"__init__", "__main__", "data"}
+
+    installed_pyc_files = destdir.rglob("*.pyc")
+    assert {f.name.split(".")[0] for f in installed_pyc_files} == {
+        "__init__",
+        "__main__",
+    }


### PR DESCRIPTION
Corresponding to #147.

`python -m installer --validate-record=all pkg.whl`

Choices are `all` `entries` (only name precedence in RECORD) and `none` (default)