### PR TITLE
Explicitly use policy=compat32

### DIFF
--- a/src/installer/utils.py
+++ b/src/installer/utils.py
@@ -12,6 +12,7 @@ from collections import namedtuple
 from configparser import ConfigParser
 from email.message import Message
 from email.parser import FeedParser
+from email.policy import compat32
 from typing import (
     TYPE_CHECKING,
     BinaryIO,
@@ -89,7 +90,7 @@ def parse_metadata_file(contents: str) -> Message:
 
     :param contents: The entire contents of the file
     """
-    feed_parser = FeedParser()
+    feed_parser = FeedParser(policy=compat32)
     feed_parser.feed(contents)
     return feed_parser.close()
 


### PR DESCRIPTION
The documentation in
https://packaging.python.org/en/latest/specifications/core-metadata/ claims that metadata should be parsed with compat32 policy.

The documentation in
https://docs.python.org/3/library/email.parser.html#feedparser-api claims that policy should always be specified and that the default will change at some point. When CPython changes the default, that would presumably introduce a bug here.