### PR TITLE
Use pythonw.exe instead of python.exe for GUI scripts on Windows

### DIFF
--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -3,6 +3,7 @@ import os
 import zipfile
 
 import pytest
+
 from installer import _scripts
 from installer.scripts import InvalidScript, Script
 

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -3,7 +3,6 @@ import os
 import zipfile
 
 import pytest
-
 from installer import _scripts
 from installer.scripts import InvalidScript, Script
 
@@ -55,7 +54,10 @@ def test_script_generate_launcher(section, kind):
 
     assert name == "foo.exe"
     assert data.startswith(launcher_data)
-    assert b"#!C:\\path to my\\python.exe\n" in data
+    if section == "gui":
+        assert b"#!C:\\path to my\\pythonw.exe\n" in data
+    else:
+        assert b"#!C:\\path to my\\python.exe\n" in data
     assert b"\nfrom foo.bar import baz\n" in code
     assert b"baz.qux()" in code
 


### PR DESCRIPTION
Signed-off-by: Frost Ming <me@frostming.com>

Resolve #180