### PR TITLE
fix: validate wheel files in a RAM friendly way

### DIFF
--- a/src/installer/sources.py
+++ b/src/installer/sources.py
@@ -287,11 +287,11 @@ class WheelFile(WheelSource):
                     f"In {self._zipfile.filename}, hash / size of {item.filename} is not included in RECORD"
                 )
             if validate_contents:
-                data = self._zipfile.read(item)
-                if not record.validate(data):
-                    issues.append(
-                        f"In {self._zipfile.filename}, hash / size of {item.filename} didn't match RECORD"
-                    )
+                with self._zipfile.open(item, "r") as stream:
+                    if not record.validate(cast("BinaryIO", stream), item.file_size):
+                        issues.append(
+                            f"In {self._zipfile.filename}, hash / size of {item.filename} didn't match RECORD"
+                        )
 
         if issues:
             raise _WheelFileValidationError(issues)

--- a/tests/test_records.py
+++ b/tests/test_records.py
@@ -1,3 +1,5 @@
+import io
+
 import pytest
 
 from installer.records import Hash, InvalidRecordEntry, RecordEntry, parse_record_file
@@ -128,7 +130,7 @@ class TestRecordEntry:
     )
     def test_validation(self, scheme, elements, data, passes_validation):
         record = RecordEntry.from_elements(*elements)
-        assert record.validate(data) == passes_validation
+        assert record.validate(io.BytesIO(data), len(data)) == passes_validation
 
     @pytest.mark.parametrize(
         ("scheme", "elements", "data", "passes_validation"), SAMPLE_RECORDS


### PR DESCRIPTION
See https://github.com/python-poetry/poetry/issues/7983

Content validation of a wheel record currently loads the entire file in memory with a `self._zipfile.read(item)`. This is extremely inefficient from big wheels (the well known PyTorch has now >2 GB wheel files) and leads to an extremely high RAM consumption. This PR fixes this behaviour by reading the zip file content in a buffered way, as other parts of the codebase are already doing. Unfortunately this required a small change to some signatures.