### PR TITLE
Validate RECORD file using streams instead of reading in-memory

### DIFF
--- a/src/installer/records.py
+++ b/src/installer/records.py
@@ -146,6 +146,10 @@ class RecordEntry:
     def validate(self, data: bytes) -> bool:
         """Validate that ``data`` matches this instance.
 
+        .. attention::
+            .. deprecated:: 0.8.0
+                Use :py:meth:`validate_stream` instead, with ``BytesIO(data)``.
+
         :param data: Contents of the file corresponding to this instance.
         :return: whether ``data`` matches hash and size.
         """

--- a/src/installer/sources.py
+++ b/src/installer/sources.py
@@ -287,11 +287,11 @@ class WheelFile(WheelSource):
                     f"In {self._zipfile.filename}, hash / size of {item.filename} is not included in RECORD"
                 )
             if validate_contents:
-                data = self._zipfile.read(item)
-                if not record.validate(data):
-                    issues.append(
-                        f"In {self._zipfile.filename}, hash / size of {item.filename} didn't match RECORD"
-                    )
+                with self._zipfile.open(item, "r") as stream:
+                    if not record.validate_stream(cast(BinaryIO, stream)):
+                        issues.append(
+                            f"In {self._zipfile.filename}, hash / size of {item.filename} didn't match RECORD"
+                        )
 
         if issues:
             raise _WheelFileValidationError(issues)

--- a/src/installer/utils.py
+++ b/src/installer/utils.py
@@ -142,6 +142,22 @@ def copyfileobj_with_hashing(
     return base64.urlsafe_b64encode(hasher.digest()).decode("ascii").rstrip("="), size
 
 
+def get_stream_length(source: BinaryIO) -> int:
+    """Read a buffer while computing the content's size.
+
+    :param source: buffer holding the source data
+    :return: size of the contents
+    """
+    size = 0
+    while True:
+        buf = source.read(_COPY_BUFSIZE)
+        if not buf:
+            break
+        size += len(buf)
+
+    return size
+
+
 def get_launcher_kind() -> "LauncherKind":  # pragma: no cover
     """Get the launcher kind for the current machine."""
     if os.name != "nt":

--- a/tests/test_records.py
+++ b/tests/test_records.py
@@ -1,3 +1,5 @@
+from io import BytesIO
+
 import pytest
 
 from installer.records import Hash, InvalidRecordEntry, RecordEntry, parse_record_file
@@ -53,21 +55,29 @@ SAMPLE_RECORDS = [
     ),
     (
         "purelib",
-        ("test4.py", "sha256=Y0sCextp4SQtQNU-MSs7SsdxD1W-gfKJtUlEbvZ3i-4", 7),
-        b"test1\n",
-        False,
-    ),
-    (
-        "purelib",
         (
-            "test5.py",
+            "test4.py",
             "sha256=Y0sCextp4SQtQNU-MSs7SsdxD1W-gfKJtUlEbvZ3i-4",
             None,
         ),
         b"test1\n",
         True,
     ),
-    ("purelib", ("test6.py", None, None), b"test1\n", True),
+    ("purelib", ("test5.py", None, None), b"test1\n", True),
+    ("purelib", ("test6.py", None, 6), b"test1\n", True),
+    (
+        "purelib",
+        ("test7.py", "sha256=Y0sCextp4SQtQNU-MSs7SsdxD1W-gfKJtUlEbvZ3i-4", 7),
+        b"test1\n",
+        False,
+    ),
+    (
+        "purelib",
+        ("test7.py", "sha256=Y0sCextp4SQtQNU-MSs7SsdxD1W-gfKJtUlEbvZ3i-4", None),
+        b"not-test1\n",
+        False,
+    ),
+    ("purelib", ("test8.py", None, 10), b"test1\n", False),
 ]
 
 
@@ -129,6 +139,14 @@ class TestRecordEntry:
     def test_validation(self, scheme, elements, data, passes_validation):
         record = RecordEntry.from_elements(*elements)
         assert record.validate(data) == passes_validation
+
+    @pytest.mark.parametrize(
+        ("scheme", "elements", "data", "passes_validation"), SAMPLE_RECORDS
+    )
+    def test_validate_stream(self, scheme, elements, data, passes_validation):
+        record = RecordEntry.from_elements(*elements)
+
+        assert record.validate_stream(BytesIO(data)) == passes_validation
 
     @pytest.mark.parametrize(
         ("scheme", "elements", "data", "passes_validation"), SAMPLE_RECORDS

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -16,6 +16,7 @@ from installer.utils import (
     construct_record_file,
     copyfileobj_with_hashing,
     fix_shebang,
+    get_stream_length,
     parse_entrypoints,
     parse_metadata_file,
     parse_wheel_filename,
@@ -132,6 +133,17 @@ class TestCopyFileObjWithHashing:
 
         assert result == (hash_, size)
         assert written_data == data
+
+
+class TestGetStreamLength:
+    def test_basic_functionality(self):
+        data = b"input data is this"
+        size = len(data)
+
+        with BytesIO(data) as source:
+            result = get_stream_length(source)
+
+        assert result == size
 
 
 class TestScript:


### PR DESCRIPTION
Supercedes and closes #183 
Fixes #185 

This ensures that the validation can be performed without loading the entire file in-memory.