### PR TITLE
Treat an empty destination the same as an unspecified one

### DIFF
--- a/src/installer/destinations.py
+++ b/src/installer/destinations.py
@@ -138,7 +138,7 @@ class SchemeDictionaryDestination(WheelDestination):
 
     def _path_with_destdir(self, scheme: Scheme, path: str) -> str:
         file = os.path.join(self.scheme_dict[scheme], path)
-        if self.destdir is not None:
+        if self.destdir:
             file_path = Path(file)
             rel_path = file_path.relative_to(file_path.anchor)
             return os.path.join(self.destdir, rel_path)


### PR DESCRIPTION
With a command line such as:
```
python -m installer --destdir="$DESTDIR" dist/*.whl
```

The destdir may not be "set" but is always passed. When relocating paths relative to the destination directory, the anchor is chopped off, resulting in paths that are relative to the process-wide current working directory, and are installed relative to there. Avoid doing any relocations against an empty destdir.

Fixes #136