### PR TITLE
Update Read the Docs config to fix build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,11 +1,19 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+# Project page: https://readthedocs.org/projects/installer/
+
 version: 2
 
 sphinx:
   builder: htmldir
   configuration: docs/conf.py
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3"
+
 python:
-  version: 3.8
   install:
     - requirements: docs/requirements.txt
     - method: pip


### PR DESCRIPTION
The documentation builds have started failing:

> **Error**
> Problem in your project's configuration. Invalid configuration option "build.os": build not found

https://readthedocs.org/projects/installer/builds/22726372/

Let's update the config to fix it.

See also: https://blog.readthedocs.com/migrate-configuration-v2/
