### PR TITLE
Use Black mirror for faster pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
-  - repo: https://github.com/psf/black
-    rev: "23.9.1"
+  - repo: https://github.com/psf/black-pre-commit-mirror
+    rev: "23.11.0"
     hooks:
       - id: black
         language_version: python3.8
@@ -12,7 +12,7 @@ repos:
         files: \.py$
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v1.5.1"
+    rev: "v1.7.1"
     hooks:
       - id: mypy
         additional_dependencies:
@@ -26,7 +26,7 @@ repos:
         args: [--prose-wrap, always]
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: "v4.4.0"
+    rev: "v4.5.0"
     hooks:
       - id: check-builtin-literals
       - id: check-added-large-files


### PR DESCRIPTION
The mirror uses a mypyc-compiled wheel which is faster.

https://github.com/psf/black-pre-commit-mirror

Also update some pins whilst we're here.