### PR TITLE
Add --overwrite-existing option that overwrites existing files

### DIFF
--- a/src/installer/__main__.py
+++ b/src/installer/__main__.py
@@ -51,6 +51,11 @@ def _get_main_parser() -> argparse.ArgumentParser:
         choices=["all", "entries", "none"],
         help="validate the wheel against certain part of its record (default=none)",
     )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="silently overwrite existing files",
+    )
     return parser
 
 
@@ -101,6 +106,7 @@ def _main(cli_args: Sequence[str], program: Optional[str] = None) -> None:
                 script_kind=get_launcher_kind(),
                 bytecode_optimization_levels=bytecode_levels,
                 destdir=args.destdir,
+                force=args.force,
             )
             installer.install(source, destination, {})
 

--- a/src/installer/__main__.py
+++ b/src/installer/__main__.py
@@ -52,7 +52,7 @@ def _get_main_parser() -> argparse.ArgumentParser:
         help="validate the wheel against certain part of its record (default=none)",
     )
     parser.add_argument(
-        "--force",
+        "--overwrite-existing",
         action="store_true",
         help="silently overwrite existing files",
     )
@@ -106,7 +106,7 @@ def _main(cli_args: Sequence[str], program: Optional[str] = None) -> None:
                 script_kind=get_launcher_kind(),
                 bytecode_optimization_levels=bytecode_levels,
                 destdir=args.destdir,
-                force=args.force,
+                overwrite_existing=args.overwrite_existing,
             )
             installer.install(source, destination, {})
 

--- a/src/installer/destinations.py
+++ b/src/installer/destinations.py
@@ -111,6 +111,7 @@ class SchemeDictionaryDestination(WheelDestination):
         hash_algorithm: str = "sha256",
         bytecode_optimization_levels: Collection[int] = (),
         destdir: Optional[str] = None,
+        force: bool = False,
     ) -> None:
         """Construct a ``SchemeDictionaryDestination`` object.
 
@@ -127,6 +128,7 @@ class SchemeDictionaryDestination(WheelDestination):
         :param destdir: A staging directory in which to write all files. This
             is expected to be the filesystem root at runtime, so embedded paths
             will be written as though this was the root.
+        :param force: silently overwrite existing files.
         """
         self.scheme_dict = scheme_dict
         self.interpreter = interpreter
@@ -134,6 +136,7 @@ class SchemeDictionaryDestination(WheelDestination):
         self.hash_algorithm = hash_algorithm
         self.bytecode_optimization_levels = bytecode_optimization_levels
         self.destdir = destdir
+        self.force = force
 
     def _path_with_destdir(self, scheme: Scheme, path: str) -> str:
         file = os.path.join(self.scheme_dict[scheme], path)
@@ -161,7 +164,7 @@ class SchemeDictionaryDestination(WheelDestination):
         - Hashes the written content, to determine the entry in the ``RECORD`` file.
         """
         target_path = self._path_with_destdir(scheme, path)
-        if os.path.exists(target_path):
+        if not self.force and os.path.exists(target_path):
             message = f"File already exists: {target_path}"
             raise FileExistsError(message)
 

--- a/src/installer/destinations.py
+++ b/src/installer/destinations.py
@@ -111,7 +111,7 @@ class SchemeDictionaryDestination(WheelDestination):
         hash_algorithm: str = "sha256",
         bytecode_optimization_levels: Collection[int] = (),
         destdir: Optional[str] = None,
-        force: bool = False,
+        overwrite_existing: bool = False,
     ) -> None:
         """Construct a ``SchemeDictionaryDestination`` object.
 
@@ -128,7 +128,7 @@ class SchemeDictionaryDestination(WheelDestination):
         :param destdir: A staging directory in which to write all files. This
             is expected to be the filesystem root at runtime, so embedded paths
             will be written as though this was the root.
-        :param force: silently overwrite existing files.
+        :param overwrite_existing: silently overwrite existing files.
         """
         self.scheme_dict = scheme_dict
         self.interpreter = interpreter
@@ -136,7 +136,7 @@ class SchemeDictionaryDestination(WheelDestination):
         self.hash_algorithm = hash_algorithm
         self.bytecode_optimization_levels = bytecode_optimization_levels
         self.destdir = destdir
-        self.force = force
+        self.overwrite_existing = overwrite_existing
 
     def _path_with_destdir(self, scheme: Scheme, path: str) -> str:
         file = os.path.join(self.scheme_dict[scheme], path)
@@ -164,7 +164,7 @@ class SchemeDictionaryDestination(WheelDestination):
         - Hashes the written content, to determine the entry in the ``RECORD`` file.
         """
         target_path = self._path_with_destdir(scheme, path)
-        if not self.force and os.path.exists(target_path):
+        if not self.overwrite_existing and os.path.exists(target_path):
             message = f"File already exists: {target_path}"
             raise FileExistsError(message)
 

--- a/tests/test_destinations.py
+++ b/tests/test_destinations.py
@@ -43,6 +43,18 @@ class TestSchemeDictionaryDestination:
             scheme_dict[scheme] = str(full_path)
         return SchemeDictionaryDestination(scheme_dict, "/my/python", "posix")
 
+    @pytest.fixture()
+    def destination_force(self, tmp_path):
+        scheme_dict = {}
+        for scheme in SCHEME_NAMES:
+            full_path = tmp_path / scheme
+            if not full_path.exists():
+                full_path.mkdir()
+            scheme_dict[scheme] = str(full_path)
+        return SchemeDictionaryDestination(
+            scheme_dict, "/my/python", "posix", force=True
+        )
+
     @pytest.mark.parametrize(
         ("scheme", "path", "data", "expected"),
         [
@@ -85,6 +97,14 @@ class TestSchemeDictionaryDestination:
         destination.write_file("data", "my_data.bin", io.BytesIO(b"my data"), False)
         with pytest.raises(FileExistsError):
             destination.write_file("data", "my_data.bin", io.BytesIO(b"my data"), False)
+
+    def test_write_record_duplicate_with_force(self, destination_force):
+        destination_force.write_file(
+            "data", "my_data.bin", io.BytesIO(b"my data"), False
+        )
+        destination_force.write_file(
+            "data", "my_data.bin", io.BytesIO(b"my data"), False
+        )
 
     def test_write_script(self, destination):
         script_args = ("my_entrypoint", "my_module", "my_function", "console")

--- a/tests/test_destinations.py
+++ b/tests/test_destinations.py
@@ -44,7 +44,7 @@ class TestSchemeDictionaryDestination:
         return SchemeDictionaryDestination(scheme_dict, "/my/python", "posix")
 
     @pytest.fixture()
-    def destination_force(self, tmp_path):
+    def destination_overwrite_existing(self, tmp_path):
         scheme_dict = {}
         for scheme in SCHEME_NAMES:
             full_path = tmp_path / scheme
@@ -52,7 +52,7 @@ class TestSchemeDictionaryDestination:
                 full_path.mkdir()
             scheme_dict[scheme] = str(full_path)
         return SchemeDictionaryDestination(
-            scheme_dict, "/my/python", "posix", force=True
+            scheme_dict, "/my/python", "posix", overwrite_existing=True
         )
 
     @pytest.mark.parametrize(
@@ -98,11 +98,13 @@ class TestSchemeDictionaryDestination:
         with pytest.raises(FileExistsError):
             destination.write_file("data", "my_data.bin", io.BytesIO(b"my data"), False)
 
-    def test_write_record_duplicate_with_force(self, destination_force):
-        destination_force.write_file(
+    def test_write_record_duplicate_with_overwrite_existing(
+        self, destination_overwrite_existing
+    ):
+        destination_overwrite_existing.write_file(
             "data", "my_data.bin", io.BytesIO(b"my data"), False
         )
-        destination_force.write_file(
+        destination_overwrite_existing.write_file(
             "data", "my_data.bin", io.BytesIO(b"my data"), False
         )
 


### PR DESCRIPTION
Took a stab at implementing what I suggested in #215.

Implement the `--force` option that, if supplied, will make installer overwrite any already existing package files instead of failing. With this flag, installer can be used in an idempotent manner, i.e. the same command can be executed multiple times with the same result:

```sh
python -m installer --force --destdir=tmp dist/*.whl
python -m installer --force --destdir=tmp dist/*.whl
python -m installer --force --destdir=tmp dist/*.whl
```

One other candidate for the option name I have in mind is  `--overwrite` which I think is more mechanically descriptive, but it might be less ubiquitous, as tools like `mv` and `cp` use `-f/--force`.

Resolves #215