### PR TITLE
Lazily import compileall

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,8 +17,8 @@ check if there is an existing issue already filed for the same, in the project's
 GitHub [issue tracker]. If not, please file a new issue.
 
 If you want to help out by fixing bugs, choose an open issue in the [issue
-tracker] to work on and claim it by posting a comment saying "I would like to
-work on this.". Feel free to ask any doubts in the issue thread.
+tracker] to work on and claim it by posting a comment saying "I would like to work
+on this.". Feel free to ask any doubts in the issue thread.
 
 While working on implementing the feature, please go ahead and file a pull
 request. Filing a pull request early allows for getting feedback as early as

--- a/src/installer/destinations.py
+++ b/src/installer/destinations.py
@@ -1,6 +1,5 @@
 """Handles all file writing and post-installation processing."""
 
-import compileall
 import io
 import os
 from pathlib import Path
@@ -242,6 +241,8 @@ class SchemeDictionaryDestination(WheelDestination):
         """Compile bytecode for a single .py file."""
         if scheme not in ("purelib", "platlib"):
             return
+
+        import compileall
 
         target_path = self._path_with_destdir(scheme, record.path)
         dir_path_to_embed = os.path.dirname(  # Without destdir


### PR DESCRIPTION
```
…\hatch on  workspaces [!] via  v3.11.7
❯ python -m timeit -n 1 -r 1 "import installer"
1 loop, best of 1: 71.6 msec per loop

…\hatch on  workspaces [!] via  v3.11.7
❯ python -m timeit -n 1 -r 1 "import compileall"
1 loop, best of 1: 14.4 msec per loop
```