### PR TITLE
Apply repo-review rule MY102

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ dynamic = [
 
 [tool.mypy]
 files = "src,tools"
-show_error_codes = true
 strict = true
 enable_error_code = [
     "ignore-without-code",


### PR DESCRIPTION
See:
https://learn.scientific-python.org/development/guides/repo-review/?repo=pypa%2Finstaller&branch=main

> MY102: MyPy show_error_codes deprecated
> 
> Must not have `show_error_codes`. It is now the default, or you can use `hide_error_codes` with the reverse value instead (since MyPy v0.990).