### PR TITLE
Remove pyproject-fmt

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,12 +25,6 @@ repos:
     hooks:
       - id: blacken-docs
 
-  - repo: https://github.com/tox-dev/pyproject-fmt
-    rev: "1.8.0"
-    hooks:
-      - id: pyproject-fmt
-        args: [--indent, "4"]
-
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.6.0
     hooks:


### PR DESCRIPTION
Since version 2.0, `pyproject-fmt` introduced a very opinionated format of the `pyproject.toml` file, which (in this maintainer's opinion) obfuscates the readability of the file in question. For that reason, I think deleting it is the best option (since `pre-commit` doesn't allow pinning hooks to a specific version and manually correcting it in the autoupdates is cumbersome).