### PR TITLE
src/installer/utils.py: sort entries before writing out RECORD file

### DIFF
--- a/src/installer/utils.py
+++ b/src/installer/utils.py
@@ -222,7 +222,7 @@ def construct_record_file(
         io.BytesIO(), encoding="utf-8", write_through=True, newline=""
     )
     writer = csv.writer(stream, delimiter=",", quotechar='"', lineterminator="\n")
-    for scheme, record in records:
+    for scheme, record in sorted(records, key=lambda x: x[1].path):
         writer.writerow(record.to_row(prefix_for_scheme(scheme)))
     stream.seek(0)
     return stream.detach()

--- a/tests/test_destinations.py
+++ b/tests/test_destinations.py
@@ -185,11 +185,11 @@ class TestSchemeDictionaryDestination:
             data = f.read()
 
         assert data == (
+            b"RECORD,,\n"
             b"../data/my_data1.bin,sha256=NV0A-M4OPuqTsHjeD6Wth_-UqrpAAAdyplcustFZ8s4,9\n"
             b"../data/my_data2.bin,sha256=lP7V8oWLqgyXCbdASNiPdsUogzPUZhht_7F8T5bC3eQ,9\n"
             b'"../data/my_data3,my_data4.bin",sha256=18krruu1gr01x-WM_9ChSASoHv0mfRAV6-B2bd9sxpo,9\n'
+            b"../scripts/my_entrypoint,sha256=_p_9nwmeIeoMBfQ0akhr1KbKn3laDydg0J7cy0Fs6JI,216\n"
             b"../scripts/my_script,sha256=M60fWvUSMJkPtw2apUvjWWwOcnRPcVy_zO4-4lpH08o,9\n"
             b"../scripts/my_script2,sha256=k9_997kTbTYQm7EXFLclVZL1m2N98rU90QX46XeMvjY,22\n"
-            b"../scripts/my_entrypoint,sha256=_p_9nwmeIeoMBfQ0akhr1KbKn3laDydg0J7cy0Fs6JI,216\n"
-            b"RECORD,,\n"
         )


### PR DESCRIPTION
This helps build reproducibility by ensuring the RECORD file is the same regardless of the order of the input files.