### PR TITLE
Add unicode entrypoint tests

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -259,6 +259,16 @@ class TestParseEntryPoints:
                 ],
                 id="cli-and-gui",
             ),
+            pytest.param(
+                """
+                    [console_scripts]
+                    நான் = ஓர்.ஒருங்குறி:கட்டளை
+                """,
+                [
+                    (" ", "ஓர்.ஒருங்குறி", "கட்டளை", "console"),
+                ],
+                id="unicode",
+            ),
         ],
     )
     def test_valid(self, script, expected):


### PR DESCRIPTION
Test for valid unicode Python identifiers (https://peps.python.org/pep-3131/) in entrypoints. Should reproduce #252 .