### PR TITLE
Fix bug when writing out scripts if the python interpreter has a space

### DIFF
--- a/src/installer/utils.py
+++ b/src/installer/utils.py
@@ -24,6 +24,8 @@ from typing import (
     cast,
 )
 
+from installer.scripts import _build_shebang
+
 if TYPE_CHECKING:
     from installer.records import RecordEntry
     from installer.scripts import LauncherKind, ScriptSection
@@ -186,7 +188,7 @@ def fix_shebang(stream: BinaryIO, interpreter: str) -> Iterator[BinaryIO]:
     if stream.read(8) == b"#!python":
         new_stream = io.BytesIO()
         # write our new shebang
-        new_stream.write(f"#!{interpreter}\n".encode())
+        new_stream.write(_build_shebang(interpreter, False) + b"\n")
         # copy the rest of the stream
         stream.seek(0)
         stream.readline()  # skip first line


### PR DESCRIPTION
In SchemeDirectoryDestination, we write:

- files, which may be part of the wheel "scripts" scheme and if so must have #!python replaced by the interpreter shebang

- entrypoints, which are built from scratch with the interpreter shebang

Only in the latter case did we ensure that we build a portable shebang.

Partially reverts commit 0edcaa769d9caf965032907151c513c46154e70f, which refactored build_shebang into a class.