### PR TITLE
PEP 639 compliance

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 build-backend = "flit_core.buildapi"
 requires = [
-    "flit_core<4,>=3.2",
+    "flit_core<4,>=3.11",
 ]
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,8 +11,9 @@ authors = [
     { name = "Pradyun Gedam", email = "pradyunsg@gmail.com" },
 ]
 requires-python = ">=3.9"
+license = "MIT"
 classifiers = [
-    "License :: OSI Approved :: MIT License",
+    "License :: OSI Approved :: MIT License",  # for compatibility with tooling such as pip-licenses
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,6 @@ authors = [
 requires-python = ">=3.9"
 license = "MIT"
 classifiers = [
-    "License :: OSI Approved :: MIT License",  # for compatibility with tooling such as pip-licenses
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
Keep the redundant Trove classifier for now, until tools such as pip-licenses support PEP 639.