### PR TITLE
fix: preserve original paths when using destdir with symlinked schemes

### DIFF
--- a/src/installer/destinations.py
+++ b/src/installer/destinations.py
@@ -155,7 +155,10 @@ class SchemeDictionaryDestination(WheelDestination):
             )
 
         if self.destdir is not None:
-            rel_path = file.relative_to(file.anchor)
+            # When using destdir, construct the path from the original (non-absolute)
+            # scheme paths so that symlinked scheme directories are preserved correctly.
+            orig_dir = Path(self.scheme_dict[scheme])
+            rel_path = (orig_dir / path).relative_to(orig_dir.anchor)
             return Path(self.destdir) / rel_path
         return file
 


### PR DESCRIPTION
## Problem

When using `destdir` with symlinked scheme paths (e.g. `/usr/bin/pyproject-build` → `/usr/bin/pyproject-build-3.13`), `_path_with_destdir` resolves symlinks before computing the destdir-relative path. This causes the resolved name (`pyproject-build-3.13`) to be used instead of the original (`pyproject-build`).

## Root Cause

`resolve()` follows symlinks on both `target_dir` and `file` (lines 140-141). When `destdir` is set, `file.relative_to(file.anchor)` operates on the resolved path, losing the original filename.

## Solution

Use unresolved paths for destdir path computation. Only use `resolve()` for the safety check that ensures files stay within the target directory.

```python
# Before:
target_dir = Path(self.scheme_dict[scheme]).resolve()
file = (target_dir / path).resolve()

# After:
target_dir = Path(self.scheme_dict[scheme])
file = target_dir / path
resolved_dir = target_dir.resolve()
resolved_file = file.resolve()
# Use resolved_* for safety check, file (unresolved) for destdir
```

Fixes #325