### PR TITLE
installer: add --interpreter option

### DIFF
--- a/src/installer/__main__.py
+++ b/src/installer/__main__.py
@@ -31,6 +31,13 @@ def _get_main_parser() -> argparse.ArgumentParser:
         help="override prefix to install packages to",
     )
     parser.add_argument(
+        "--interpreter",
+        "-i",
+        type=str,
+        default=sys.executable,
+        help=f"interpreter (defaults to {sys.executable})",
+    )
+    parser.add_argument(
         "--compile-bytecode",
         action="append",
         metavar="level",
@@ -102,7 +109,7 @@ def _main(cli_args: Sequence[str], program: str | None = None) -> None:
                 source.validate_record(validate_contents=args.validate_record == "all")
             destination = SchemeDictionaryDestination(
                 scheme_dict=_get_scheme_dict(source.distribution, prefix=args.prefix),
-                interpreter=sys.executable,
+                interpreter=args.interpreter,
                 script_kind=get_launcher_kind(),
                 bytecode_optimization_levels=bytecode_levels,
                 destdir=args.destdir,


### PR DESCRIPTION
The currently running Python might not be the right one for the installed wheels, so add an option to allow the interpreter to be overridden.

This is essential in cross/distro builds where we want to install a wheel into a working directory to build a distro package (eg a rpm or deb) with pypa/installer, but the currently running python on the build host might not be the right path for the scripts to use on the target.