### PR TITLE
Normalize RECORD paths when writing

### DIFF
--- a/src/installer/records.py
+++ b/src/installer/records.py
@@ -6,7 +6,7 @@ import hashlib
 import os
 from collections.abc import Iterable, Iterator
 from dataclasses import dataclass
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 from typing import BinaryIO, cast
 
 from installer.utils import copyfileobj_with_hashing, get_stream_length
@@ -106,8 +106,7 @@ class RecordEntry:
             path = self.path
 
         # Convert Windows paths to use / for consistency
-        if os.sep == "\\":
-            path = path.replace("\\", "/")  # pragma: no cover
+        path = PureWindowsPath(path).as_posix()
 
         return (
             path,

--- a/tests/test_records.py
+++ b/tests/test_records.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 import pytest
 
+import installer.records
 from installer.records import Hash, InvalidRecordEntry, RecordEntry, parse_record_file
 
 
@@ -175,6 +176,34 @@ class TestRecordEntry:
             ]
         )
         assert record.to_row("prefix/") == expected_row
+
+    def test_string_representation_with_backslash_path(self, monkeypatch):
+        monkeypatch.setattr(installer.records.os, "sep", "/")
+        record = RecordEntry.from_elements(
+            r"distribution-1.0.dist-info\RECORD",
+            "",
+            "",
+        )
+
+        assert record.to_row() == (
+            "distribution-1.0.dist-info/RECORD",
+            "",
+            "",
+        )
+
+    def test_string_representation_with_backslash_path_and_prefix(self, monkeypatch):
+        monkeypatch.setattr(installer.records.os, "sep", "/")
+        record = RecordEntry.from_elements(
+            r"bin\script.py",
+            "",
+            "",
+        )
+
+        assert record.to_row("prefix/") == (
+            "prefix/bin/script.py",
+            "",
+            "",
+        )
 
     def test_equality(self):
         record = RecordEntry.from_elements(


### PR DESCRIPTION
﻿Fixes #158.

This normalizes Windows-style separators when writing `RecordEntry` rows, regardless of the platform doing the write.

That keeps written RECORD paths consistent even if a `RecordEntry` was created from a Windows-style path on another platform.

Tests:

```text
python -m pytest tests/test_records.py -k "backslash_path or string_representation"
python -m pytest tests/test_records.py
python -m pytest --cov=installer --cov-fail-under=100 --cov-report=term-missing --cov-context=test -n auto tests
python -m ruff check src/installer/records.py tests/test_records.py
python -m ruff format --check src/installer/records.py tests/test_records.py
python -m pre_commit run --files src/installer/records.py tests/test_records.py
git diff --check
```
