### PR TITLE
fix: replace deprecated posixpath.commonprefix() with startswith()

### DIFF
--- a/src/installer/_core.py
+++ b/src/installer/_core.py
@@ -42,7 +42,7 @@ def _determine_scheme(
     data_dir = source.data_dir
 
     # If it's in not `{distribution}-{version}.data`, then it's in root_scheme.
-    if posixpath.commonprefix([data_dir, path]) != data_dir:
+    if not path.startswith(data_dir + "/"):
         return root_scheme, path
 
     # Figure out which scheme this goes to.

--- a/src/installer/sources.py
+++ b/src/installer/sources.py
@@ -220,7 +220,7 @@ class WheelFile(WheelSource):
             name[len(base) + 1 :]
             for name in self._zipfile.namelist()
             if name[-1:] != "/"
-            if base == posixpath.commonprefix([name, base])
+            if name.startswith(base + "/")
         ]
 
     def read_dist_info(self, filename: str) -> str:
@@ -259,9 +259,7 @@ class WheelFile(WheelSource):
 
             record_args = record_mapping.pop(item.filename, None)
 
-            if self.dist_info_dir == posixpath.commonprefix(
-                [self.dist_info_dir, item.filename]
-            ) and item.filename.split("/")[-1] in ("RECORD.p7s", "RECORD.jws"):
+            if item.filename.startswith(self.dist_info_dir + "/") and item.filename.split("/")[-1] in ("RECORD.p7s", "RECORD.jws"):
                 # both are for digital signatures, and not mentioned in RECORD
                 if record_args is not None:
                     # Incorrectly contained

--- a/src/installer/sources.py
+++ b/src/installer/sources.py
@@ -259,7 +259,9 @@ class WheelFile(WheelSource):
 
             record_args = record_mapping.pop(item.filename, None)
 
-            if item.filename.startswith(self.dist_info_dir + "/") and item.filename.split("/")[-1] in ("RECORD.p7s", "RECORD.jws"):
+            if item.filename.startswith(
+                self.dist_info_dir + "/"
+            ) and item.filename.split("/")[-1] in ("RECORD.p7s", "RECORD.jws"):
                 # both are for digital signatures, and not mentioned in RECORD
                 if record_args is not None:
                     # Incorrectly contained


### PR DESCRIPTION
os.path.commonprefix() is deprecated in Python 3.15 and emits a DeprecationWarning. Replace all three usages with str.startswith() checks, which are also semantically more correct (commonprefix does character-level matching and can produce false positives for paths sharing a string prefix but not a directory boundary).

Without this, `TestInstall.test_skips_pycache_and_warns` fails with Python 3.15 because the code generated more warnings than expected.