### PR TITLE
perf: add an early return when there are no optimization levels to compile bytecode for

### DIFF
--- a/src/installer/destinations.py
+++ b/src/installer/destinations.py
@@ -255,7 +255,10 @@ class SchemeDictionaryDestination(WheelDestination):
 
     def _compile_bytecode(self, scheme: Scheme, record: RecordEntry) -> None:
         """Compile bytecode for a single .py file."""
-        if scheme not in ("purelib", "platlib"):
+        if not self.bytecode_optimization_levels or scheme not in (
+            "purelib",
+            "platlib",
+        ):
             return
 
         import compileall


### PR DESCRIPTION
Even if no bytecode should be compiled, several unnecessary path operations are performed for each record entry. We can avoid this with an early return.