### PR TITLE
Recognize build tags in wheel data directories

### DIFF
--- a/src/installer/sources.py
+++ b/src/installer/sources.py
@@ -167,6 +167,7 @@ class WheelFile(WheelSource):
 
         basename = Path(f.filename).name
         parsed_name = parse_wheel_filename(basename)
+        self._build_tag = parsed_name.build_tag
         super().__init__(
             version=parsed_name.version,
             distribution=parsed_name.distribution,
@@ -211,6 +212,14 @@ class WheelFile(WheelSource):
             )
 
         return dist_info_dir
+
+    @cached_property
+    def data_dir(self) -> str:
+        """Name of the data directory."""
+        if self._build_tag is None:
+            return super().data_dir
+
+        return f"{self.distribution}-{self.version}-{self._build_tag}.data"
 
     @property
     def dist_info_filenames(self) -> list[str]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,12 +10,19 @@ def fancy_wheel(tmp_path):
 
 
 @pytest.fixture
+def fancy_wheel_with_build_tag(tmp_path):
+    return mock_wheel(tmp_path, "fancy", build_tag="1337")
+
+
+@pytest.fixture
 def another_fancy_wheel(tmp_path):
     return mock_wheel(tmp_path, "another_fancy")
 
 
-def mock_wheel(tmp_path, name):
-    path = tmp_path / f"{name}-1.0.0-py2.py3-none-any.whl"
+def mock_wheel(tmp_path, name, build_tag=None):
+    wheel_build_tag = f"-{build_tag}" if build_tag is not None else ""
+    data_dir = f"{name}-1.0.0{wheel_build_tag}.data"
+    path = tmp_path / f"{name}-1.0.0{wheel_build_tag}-py2.py3-none-any.whl"
     files = {
         f"{name}/": b"""""",
         f"{name}/__init__.py": b"""\
@@ -27,8 +34,8 @@ def mock_wheel(tmp_path, name):
                 from . import main
                 main()
         """,
-        f"{name}-1.0.0.data/data/{name}/": b"""""",
-        f"{name}-1.0.0.data/data/{name}/data.py": b"""\
+        f"{data_dir}/data/{name}/": b"""""",
+        f"{data_dir}/data/{name}/data.py": b"""\
             # put me in data
         """,
         f"{name}-1.0.0.dist-info/": b"""""",
@@ -63,7 +70,7 @@ def mock_wheel(tmp_path, name):
         f"{name}-1.0.0.dist-info/RECORD": f"""\
             {name}/__init__.py,sha256=qZ2qq7xVBAiUFQVv-QBHhdtCUF5p1NsWwSOiD7qdHN0,36
             {name}/__main__.py,sha256=Wd4SyWJOIMsHf_5-0oN6aNFwen8ehJnRo-erk2_K-eY,61
-            {name}-1.0.0.data/data/{name}/data.py,sha256=nuFRUNQF5vP7FWE-v5ysyrrfpIaAvfzSiGOgfPpLOeI,17
+            {data_dir}/data/{name}/data.py,sha256=nuFRUNQF5vP7FWE-v5ysyrrfpIaAvfzSiGOgfPpLOeI,17
             {name}-1.0.0.dist-info/top_level.txt,sha256=SW-yrrF_c8KlserorMw54inhLjZ3_YIuLz7fYT4f8ao,6
             {name}-1.0.0.dist-info/entry_points.txt,sha256=AxJl21_zgoNWjCfvSkC9u_rWSzGyCtCzhl84n979jCc,75
             {name}-1.0.0.dist-info/WHEEL,sha256=1DrXMF1THfnBjsdS5sZn-e7BKcmUn7jnMbShGeZomgc,84

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -8,7 +8,7 @@ import pytest
 from installer import install
 from installer.exceptions import InvalidWheelSource
 from installer.records import RecordEntry
-from installer.sources import WheelSource
+from installer.sources import WheelFile, WheelSource
 
 
 # --------------------------------------------------------------------------------------
@@ -779,6 +779,35 @@ class TestInstall:
                     ],
                 ),
             ]
+        )
+
+    def test_handles_wheel_data_dir_with_build_tag(self, fancy_wheel_with_build_tag):
+        destination = mock.Mock()
+
+        def custom_write_file(scheme, path, stream, is_executable):
+            stream.read()
+            return (path, scheme, 0)
+
+        destination.write_file.side_effect = custom_write_file
+        destination.write_script.side_effect = lambda name, module, attr, section: (
+            name,
+            module,
+            attr,
+            section,
+        )
+
+        with WheelFile.open(fancy_wheel_with_build_tag) as source:
+            install(
+                source=source,
+                destination=destination,
+                additional_metadata={},
+            )
+
+        destination.write_file.assert_any_call(
+            scheme="data",
+            path="fancy/data.py",
+            stream=mock.ANY,
+            is_executable=False,
         )
 
     def test_errors_out_when_given_invalid_scheme_in_data(self, mock_destination):

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -130,6 +130,10 @@ class TestWheelFile:
         with WheelFile.open(denorm) as source:
             assert source.dist_info_filenames
 
+    def test_build_tag_is_part_of_data_dir(self, fancy_wheel_with_build_tag):
+        with WheelFile.open(fancy_wheel_with_build_tag) as source:
+            assert source.data_dir == "fancy-1.0.0-1337.data"
+
     def test_requires_dist_info_name_match(self, fancy_wheel):
         misnamed = fancy_wheel.rename(
             fancy_wheel.parent / "misnamed-1.0.0-py3-none-any.whl"


### PR DESCRIPTION
Fixes #193.

This updates `WheelFile.data_dir` to include the optional wheel build tag parsed from the wheel filename, so files under directories such as `foo-0.4.2-1337.data/` are routed through the wheel `.data` scheme instead of being treated as root-scheme files.

The base `WheelSource` behavior is unchanged for callers that construct sources without a wheel filename.

Tests added:
- `WheelFile.data_dir` includes the build tag for build-tagged wheels.
- `install()` routes a build-tagged wheel data file to the `data` scheme.

Checks run locally:
- `PYTHONPATH=src python -m pytest tests\test_sources.py::TestWheelFile::test_build_tag_is_part_of_data_dir tests\test_core.py::TestInstall::test_handles_wheel_data_dir_with_build_tag -q`
- `PYTHONPATH=src python -m pytest tests\test_sources.py tests\test_core.py -q`
- `PYTHONPATH=src python -m pytest -q`
- `python -m ruff check src tests`
- `python -m ruff format --check src tests`
- `PYTHONPATH=src python -m mypy src`
- `git diff --check`