### PR TITLE
Skip duplicate wheel scripts generated from entry points

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,12 @@
 # Changelog
 
+## Unreleased
+
+- Skip installing legacy scripts from wheels when an entry point has already
+  generated a script at the same path (#315)
+
 ## v1.0.1 (May 11, 2026)
+
 - Include docs and tests in sdist again (#322)
 - Fix long path issue on Windows (#321)
 - Fix date in changelog (#324)

--- a/src/installer/_core.py
+++ b/src/installer/_core.py
@@ -62,6 +62,16 @@ def _determine_scheme(
     return cast("Scheme", scheme_name), posixpath.join(*reversed(parts[:-1]))
 
 
+def _record_path(record: RecordEntry) -> str:
+    record_object = cast("object", record)
+
+    if isinstance(record_object, RecordEntry):
+        return record_object.path
+
+    # Tests use tuples for mocked records to make call assertions smaller.
+    return cast("tuple[str, ...]", record_object)[0]
+
+
 def install(
     source: WheelSource,
     destination: WheelDestination,
@@ -80,6 +90,7 @@ def install(
     # RECORD handling
     record_file_path = posixpath.join(source.dist_info_dir, "RECORD")
     written_records = []
+    generated_script_paths = set()
 
     # Write the entry_points based scripts.
     if "entry_points.txt" in source.dist_info_filenames:
@@ -92,6 +103,7 @@ def install(
                 section=section,
             )
             written_records.append((Scheme("scripts"), record))
+            generated_script_paths.add(_record_path(record))
 
     # Write all the files from the wheel.
     for record_elements, stream, is_executable in source.get_contents():
@@ -120,6 +132,18 @@ def install(
             source=source,
             root_scheme=root_scheme,
         )
+
+        if scheme == "scripts" and destination_path in generated_script_paths:
+            warnings.warn(
+                (
+                    f"Skip installing {path} from {source.distribution} because it"
+                    " would write to the same path as an entry point script."
+                ),
+                RuntimeWarning,
+                stacklevel=2,
+            )
+            continue
+
         record = destination.write_file(
             scheme=scheme,
             path=destination_path,

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -781,6 +781,76 @@ class TestInstall:
             ]
         )
 
+    def test_skips_data_script_if_entrypoint_writes_same_path(self, mock_destination):
+        source = FakeWheelSource(
+            distribution="fancy",
+            version="1.0.0",
+            regular_files={
+                "fancy-1.0.0.data/scripts/fancy": b"""\
+                    # legacy script with same name as the entry point
+                """,
+            },
+            dist_info_files={
+                "entry_points.txt": b"""\
+                    [console_scripts]
+                    fancy = fancy:main
+                """,
+                "WHEEL": b"""\
+                    Wheel-Version: 1.0
+                    Generator: magic (1.0.0)
+                    Root-Is-Purelib: true
+                    Tag: py3-none-any
+                """,
+                "METADATA": b"""\
+                    Metadata-Version: 2.1
+                    Name: fancy
+                    Version: 1.0.0
+                """,
+            },
+        )
+
+        with pytest.warns(RuntimeWarning, match="same path as an entry point"):
+            install(
+                source=source,
+                destination=mock_destination,
+                additional_metadata={},
+            )
+
+        assert mock_destination.write_file.call_args_list == [
+            mock.call(
+                scheme="purelib",
+                path="fancy-1.0.0.dist-info/METADATA",
+                stream=mock.ANY,
+                is_executable=False,
+            ),
+            mock.call(
+                scheme="purelib",
+                path="fancy-1.0.0.dist-info/WHEEL",
+                stream=mock.ANY,
+                is_executable=False,
+            ),
+            mock.call(
+                scheme="purelib",
+                path="fancy-1.0.0.dist-info/entry_points.txt",
+                stream=mock.ANY,
+                is_executable=False,
+            ),
+        ]
+        mock_destination.finalize_installation.assert_called_once_with(
+            scheme="purelib",
+            record_file_path="fancy-1.0.0.dist-info/RECORD",
+            records=[
+                ("scripts", ("fancy", "fancy", "main", "console")),
+                ("purelib", ("fancy-1.0.0.dist-info/METADATA", "purelib", 0)),
+                ("purelib", ("fancy-1.0.0.dist-info/WHEEL", "purelib", 0)),
+                (
+                    "purelib",
+                    ("fancy-1.0.0.dist-info/entry_points.txt", "purelib", 0),
+                ),
+                ("purelib", RecordEntry("fancy-1.0.0.dist-info/RECORD", None, None)),
+            ],
+        )
+
     def test_errors_out_when_given_invalid_scheme_in_data(self, mock_destination):
         # Create a fake wheel
         source = FakeWheelSource(


### PR DESCRIPTION
When a wheel provides both an entry point and a `.data/scripts` file with the same script path, installer generates the entry point first and then raises `FileExistsError` while unpacking the legacy script.

This keeps the generated entry point script, skips the conflicting legacy script, and emits a warning that points at the wheel path being skipped. That matches the practical compatibility behavior described in the issue without changing the normal overwrite policy for unrelated files.

fixes #315

Tests:
- `py -3 -m pytest tests/test_core.py::TestInstall::test_skips_data_script_if_entrypoint_writes_same_path -q`
- `py -3 -m pytest tests/test_core.py -q`
- `py -3 -m pytest -q`
- `py -3 -m ruff check src/installer/_core.py tests/test_core.py`
- `py -3 -m mypy src`