### PR TITLE
Use os.path.commonpath over commonprefix

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Use `os.path.commonpath` instead of `os.path.commonprefix` to address deprecation
+  warnings on Python 3.15 (#345)
+
 ## v1.0.1 (May 11, 2026)
 - Include docs and tests in sdist again (#322)
 - Fix long path issue on Windows (#321)

--- a/src/installer/_core.py
+++ b/src/installer/_core.py
@@ -41,7 +41,7 @@ def _determine_scheme(
     data_dir = source.data_dir
 
     # If it's in not `{distribution}-{version}.data`, then it's in root_scheme.
-    if posixpath.commonprefix([data_dir, path]) != data_dir:
+    if posixpath.commonpath([data_dir, path]) != data_dir:
         return root_scheme, path
 
     # Figure out which scheme this goes to.

--- a/src/installer/sources.py
+++ b/src/installer/sources.py
@@ -220,7 +220,7 @@ class WheelFile(WheelSource):
             name[len(base) + 1 :]
             for name in self._zipfile.namelist()
             if name[-1:] != "/"
-            if base == posixpath.commonprefix([name, base])
+            if base == posixpath.commonpath([name, base])
         ]
 
     def read_dist_info(self, filename: str) -> str:
@@ -259,7 +259,7 @@ class WheelFile(WheelSource):
 
             record_args = record_mapping.pop(item.filename, None)
 
-            if self.dist_info_dir == posixpath.commonprefix(
+            if self.dist_info_dir == posixpath.commonpath(
                 [self.dist_info_dir, item.filename]
             ) and item.filename.split("/")[-1] in ("RECORD.p7s", "RECORD.jws"):
                 # both are for digital signatures, and not mentioned in RECORD


### PR DESCRIPTION
`commonprefix` was deprecated in Python 3.15 as it does a character-by-character check which is 99% likely to be not what you actually want.

`commonpath` does the sane thing of returning only valid paths (aka respecting the directory structure).

Having briefly read the code, I assume that there is no mixing of absolute and relative paths at these callsites. If there is, then `commonpath` won't work. 

This was caught in pip's test suite on Python 3.15.