### PR TITLE
Silence bytecode compile failures during install

### DIFF
--- a/src/installer/destinations.py
+++ b/src/installer/destinations.py
@@ -268,7 +268,7 @@ class SchemeDictionaryDestination(WheelDestination):
 
         for level in self.bytecode_optimization_levels:
             compileall.compile_file(
-                target_path, optimize=level, quiet=1, ddir=dir_path_to_embed
+                target_path, optimize=level, quiet=2, ddir=dir_path_to_embed
             )
 
     def finalize_installation(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,4 +1,6 @@
 import os
+import sys
+import types
 
 import pytest
 
@@ -88,6 +90,31 @@ def test_main_no_pyc(fancy_wheel, tmp_path):
 
     installed_pyc_files = destdir.rglob("*.pyc")
     assert set(installed_pyc_files) == set()
+
+
+def test_main_silences_bytecode_compile_failures(
+    fancy_wheel, tmp_path, monkeypatch, capsys
+):
+    calls = []
+
+    def fake_compile_file(*args, **kwargs):
+        calls.append((args, kwargs))
+        if kwargs["quiet"] != 2:
+            sys.stderr.write("*** Error compiling test module...\n")
+        return False
+
+    monkeypatch.setitem(
+        sys.modules, "compileall", types.SimpleNamespace(compile_file=fake_compile_file)
+    )
+
+    destdir = tmp_path / "dest"
+
+    main([str(fancy_wheel), "-d", str(destdir)], "python -m installer")
+
+    captured = capsys.readouterr()
+    assert captured.err == ""
+    assert calls
+    assert all(kwargs["quiet"] == 2 for _, kwargs in calls)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- silence bytecode compilation failures by using `compileall`'s fully quiet mode
- keep installer behavior aligned with pip by still ignoring compile failures instead of aborting installation
- add a regression test that locks in silent handling for failed bytecode compilation

Closes #311

## Problem
`installer` currently ignores bytecode compilation failures, but it still emits `*** Error compiling ...` messages to stderr. That is noisy for wheels that intentionally contain Python files targeting newer syntax, and it does not match pip's behavior noted in the issue discussion.

## Testing
- `uv run --python 3.10 --with pytest pytest tests/test_main.py -q`
- `uv run --python 3.10 --with pytest --with pytest-cov --with pytest-xdist pytest -q`
- `uv run --python 3.10 --with ruff ruff check src/installer/destinations.py tests/test_main.py`
- `uv run --python 3.10 --with ruff ruff format --check src/installer/destinations.py tests/test_main.py`

## Notes
- I did not change install success/failure semantics; this only removes the noisy stderr output while preserving the existing ignore-and-continue behavior discussed on the issue.