### PR TITLE
Always set owner read bit for executable files

### DIFF
--- a/src/installer/utils.py
+++ b/src/installer/utils.py
@@ -7,6 +7,7 @@ import hashlib
 import io
 import os
 import re
+import stat
 import sys
 from collections import namedtuple
 from collections.abc import Callable, Iterable, Iterator
@@ -269,4 +270,5 @@ def _current_umask() -> int:
 # https://github.com/pypa/pip/blob/0f21fb92/src/pip/_internal/utils/unpacking.py#L93
 def make_file_executable(path: Path) -> None:
     """Make the file at the provided path executable."""
-    path.chmod(0o777 & ~_current_umask() | 0o111)
+    execute_bits = stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
+    path.chmod(0o777 & ~_current_umask() | execute_bits | stat.S_IRUSR)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,12 +2,15 @@
 
 import base64
 import hashlib
+import os
+import stat
 import textwrap
 from email.message import Message
 from io import BytesIO
 
 import pytest
 
+import installer.utils as utils
 from installer.records import RecordEntry
 from installer.utils import (
     WheelFilename,
@@ -142,6 +145,46 @@ class TestGetStreamLength:
             result = get_stream_length(source)
 
         assert result == size
+
+
+class TestMakeFileExecutable:
+    @pytest.mark.parametrize(
+        ("umask", "expected_mode"),
+        [
+            pytest.param(0o022, 0o755, id="typical"),
+            pytest.param(0o777, 0o511, id="restrictive"),
+        ],
+    )
+    def test_sets_owner_read_bit(self, monkeypatch, umask, expected_mode):
+        class FakePath:
+            def __init__(self):
+                self.mode = None
+
+            def chmod(self, mode):
+                self.mode = mode
+
+        path = FakePath()
+        monkeypatch.setattr(utils, "_current_umask", lambda: umask)
+
+        utils.make_file_executable(path)
+
+        assert path.mode == expected_mode
+
+    @pytest.mark.skipif(
+        os.name == "nt",
+        reason="Windows chmod does not expose POSIX execute bits",
+    )
+    def test_sets_owner_read_bit_with_restrictive_umask(self, tmp_path):
+        path = tmp_path / "executable"
+        old_umask = os.umask(0o777)
+        try:
+            path.write_bytes(b"executable")
+            utils.make_file_executable(path)
+        finally:
+            os.umask(old_umask)
+
+        mode = stat.S_IMODE(path.stat().st_mode)
+        assert mode == 0o511
 
 
 class TestScript:


### PR DESCRIPTION
## Summary

Fixes executable file permissions with restrictive umasks.

## What changed

- Ensure `make_file_executable()` always sets the owner read bit.
- Add regression coverage for typical and restrictive umask values.
- No new dependencies.

## Why

With a restrictive umask such as `0o777`, executable files were chmodded to `0o111`, leaving the owner unable to read the file. This keeps the existing executable-bit behavior while ensuring owner read permission is present.

## Tests

- [x] `uvx nox -s test-3.14 -- --no-cov tests/test_utils.py -k MakeFileExecutable`
- [x] WSL POSIX smoke with real `os.umask(0o777)` produced `0o511`
- [x] `uvx nox -s test-3.14`
- [x] `uvx 'nox[pbs]' -s lint`

Closes #140