### PR TITLE
Normalize RECORD paths when writing

### DIFF
--- a/src/installer/records.py
+++ b/src/installer/records.py
@@ -6,7 +6,7 @@ import hashlib
 import os
 from collections.abc import Iterable, Iterator
 from dataclasses import dataclass
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 from typing import BinaryIO, cast
 
 from installer.utils import copyfileobj_with_hashing, get_stream_length
@@ -106,8 +106,7 @@ class RecordEntry:
             path = self.path
 
         # Convert Windows paths to use / for consistency
-        if os.sep == "\\":
-            path = path.replace("\\", "/")  # pragma: no cover
+        path = PureWindowsPath(path).as_posix()
 
         return (
             path,

--- a/tests/test_records.py
+++ b/tests/test_records.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 import pytest
 
+import installer.records
 from installer.records import Hash, InvalidRecordEntry, RecordEntry, parse_record_file
 
 
@@ -175,6 +176,16 @@ class TestRecordEntry:
             ]
         )
         assert record.to_row("prefix/") == expected_row
+
+    def test_string_representation_normalizes_backslash_path(self, monkeypatch):
+        monkeypatch.setattr(installer.records.os, "sep", "/")
+        record = RecordEntry.from_elements(
+            r"distribution-1.0.dist-info\RECORD",
+            "",
+            "",
+        )
+
+        assert record.to_row() == ("distribution-1.0.dist-info/RECORD", "", "")
 
     def test_equality(self):
         record = RecordEntry.from_elements(


### PR DESCRIPTION
## Summary

Fixes RECORD writing so Windows-style separators are normalized to forward slashes regardless of the platform doing the write.

## What changed

- Updated `RecordEntry.to_row()` to normalize the output path with `PureWindowsPath(...).as_posix()`.
- Added a focused regression test that simulates a non-Windows writer receiving a backslash path.
- No new dependencies.

## Why

`RecordEntry.to_row()` previously only replaced backslashes when `os.sep == \`. That meant a `RecordEntry` containing a Windows-style path could still write backslashes when serialized on another platform. RECORD paths should use `/` consistently.

## Tests

- [x] `python -m pytest tests/test_records.py::TestRecordEntry::test_string_representation_normalizes_backslash_path -q`
- [x] `python -m pytest tests/test_records.py -q`
- [x] `python -m ruff check src\installer\records.py tests\test_records.py`
- [x] `python -m ruff format --check src\installer\records.py tests\test_records.py`
- [x] `python -m nox -s test-3.14`
- [x] `python -m pre_commit run --files src\installer\records.py tests\test_records.py`

Closes #158