### PR TITLE
Allow building this package with flit-core 4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 build-backend = "flit_core.buildapi"
 requires = [
-    "flit_core<4,>=3.11",
+    "flit_core<5,>=3.11",
 ]
 
 [project]


### PR DESCRIPTION
The package already uses a [project] table in pyproject.toml, and it is compatible with the latest flit-core release.