### PR TITLE
Normalize RECORD paths when writing

### DIFF
--- a/src/installer/records.py
+++ b/src/installer/records.py
@@ -106,8 +106,7 @@ class RecordEntry:
             path = self.path
 
         # Convert Windows paths to use / for consistency
-        if os.sep == "\\":
-            path = path.replace("\\", "/")  # pragma: no cover
+        path = path.replace("\\", "/")
 
         return (
             path,

--- a/tests/test_records.py
+++ b/tests/test_records.py
@@ -176,6 +176,11 @@ class TestRecordEntry:
         )
         assert record.to_row("prefix/") == expected_row
 
+    def test_to_row_normalizes_windows_path_on_any_platform(self):
+        record = RecordEntry.from_elements(r"package\module.py", "", "")
+
+        assert record.to_row() == ("package/module.py", "", "")
+
     def test_equality(self):
         record = RecordEntry.from_elements(
             "file.py",


### PR DESCRIPTION
Fixes #158.

`RecordEntry.to_row()` currently normalizes backslashes only when running on Windows. A `RecordEntry` can also contain a path read from a Windows-generated RECORD while installer itself is running on another platform, so the serialized path must be normalized independently of the host OS.

Normalize backslashes to forward slashes unconditionally in `to_row()`, matching the existing normalization performed when parsing RECORD rows.

A regression test constructs a Windows-style path and verifies that `to_row()` emits a forward-slash RECORD path on every platform.

Validation:
- clean one-commit branch on current upstream main at preparation time
- full fork GitHub Actions matrix passes on head `9ef6a9f`