### PR TITLE
Read RECORD with the default csv reader, not str.splitlines()

### DIFF
--- a/src/installer/records.py
+++ b/src/installer/records.py
@@ -222,7 +222,8 @@ def parse_record_file(rows: Iterable[str]) -> Iterator[tuple[str, str, str]]:
     Returns an iterable of 3-value tuples, that can be passed to
     :any:`RecordEntry.from_elements`.
 
-    :param rows: iterator providing lines of a RECORD (no trailing newlines).
+    :param rows: iterator providing lines of a RECORD (no trailing newlines),
+        or a text stream opened with ``newline=""``.
     """
     reader = csv.reader(rows, delimiter=",", quotechar='"', lineterminator="\n")
     for row_index, elements in enumerate(reader):

--- a/src/installer/sources.py
+++ b/src/installer/sources.py
@@ -1,5 +1,6 @@
 """Source of information about a wheel file."""
 
+import io
 import posixpath
 import stat
 import zipfile
@@ -242,9 +243,10 @@ class WheelFile(WheelSource):
         :param validate_contents: Whether to validate content integrity.
         """
         try:
-            record_lines = self.read_dist_info("RECORD").splitlines()
+            record_text = self.read_dist_info("RECORD")
             record_mapping = {
-                record[0]: record for record in parse_record_file(record_lines)
+                record[0]: record
+                for record in parse_record_file(io.StringIO(record_text, newline=""))
             }
         except Exception as exc:
             raise _WheelFileValidationError(
@@ -317,8 +319,8 @@ class WheelFile(WheelSource):
         :any:`AssertionError` will be raised.
         """
         # Convert the record file into a useful mapping
-        record_lines = self.read_dist_info("RECORD").splitlines()
-        records = parse_record_file(record_lines)
+        record_text = self.read_dist_info("RECORD")
+        records = parse_record_file(io.StringIO(record_text, newline=""))
         record_mapping = {record[0]: record for record in records}
 
         for item in self._zipfile.infolist():

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -7,8 +7,9 @@ from hashlib import sha256
 import pytest
 
 from installer.exceptions import InstallerError
-from installer.records import parse_record_file
+from installer.records import Hash, RecordEntry, parse_record_file
 from installer.sources import WheelFile, WheelSource
+from installer.utils import Scheme, construct_record_file
 
 
 class TestWheelSource:
@@ -361,3 +362,40 @@ class TestWheelFile:
             ),
         ):
             source.validate_record(validate_contents=True)
+
+    @pytest.mark.parametrize(
+        "odd_path",
+        [
+            pytest.param("fancy/we\nird.py", id="newline"),
+            pytest.param("fancy/we\u2028ird.py", id="line-separator"),
+        ],
+    )
+    def test_reads_record_with_odd_characters_in_path(self, fancy_wheel, odd_path):
+        # RECORD is a CSV file, and the spec requires it to be "readable with the
+        # default reader of Python's csv module". str.splitlines() is not that
+        # reader: it drops the terminator inside a quoted field, and it also
+        # splits on characters csv does not treat as row separators.
+        contents = b"# odd\n"
+
+        with WheelFile.open(fancy_wheel) as source:
+            record_file_contents = source.read_dist_info("RECORD")
+
+        digest = urlsafe_b64encode(sha256(contents).digest()).decode().rstrip("=")
+        entry = RecordEntry(
+            path=odd_path, hash_=Hash("sha256", digest), size=len(contents)
+        )
+        new_record = construct_record_file([(Scheme("purelib"), entry)]).read().decode()
+
+        with zipfile.ZipFile(fancy_wheel, "a") as archive:
+            archive.writestr(odd_path, contents)
+        replace_file_in_zip(
+            fancy_wheel,
+            filename="fancy-1.0.0.dist-info/RECORD",
+            content=record_file_contents + new_record,
+        )
+
+        with WheelFile.open(fancy_wheel) as source:
+            source.validate_record(validate_contents=True)
+            paths = [record[0] for record, _, _ in source.get_contents()]
+
+        assert odd_path in paths


### PR DESCRIPTION
`construct_record_file` writes RECORD with `csv.writer`, so a path containing a newline comes out correctly quoted. Both read sites — `WheelFile.validate_record` and `WheelFile.get_contents` — called `str.splitlines()` before handing the result to `parse_record_file`, so installer cannot read the RECORD it just wrote.

Measured on `59f0a65`, using installer's own writer and then its own reader:

```
wrote  '"demo/we\nird.py",sha256=...,6'
read   'demo/weird.py'           (the newline is gone)

validate_record() on that wheel:
  In demo-1.0-py3-none-any.whl, demo/we
  ird.py is not mentioned in RECORD
```

`splitlines()` also splits on characters `csv` does not treat as row separators. I ran the writer and then the reader for all ten: `\n` and `\r` come back with the character silently deleted; `\v`, `\f`, `\x1c`, `\x1d`, `\x1e`, `\x85`, U+2028 and U+2029 raise `expected 3 elements, got 1`. All ten read back byte-identical through `csv.reader` over the same file.

The recording-installed-projects spec pins the dialect: RECORD "must be readable with the default `reader` of Python's `csv` module", line terminator "either `\r\n` or `\n`". Interposing `splitlines()` is a different, larger set of terminators.

Fix is to hand the RECORD text to `parse_record_file` as `io.StringIO(text, newline="")`.

Ran `pytest tests/`: 152 passed, `coverage report` still 100%. Reverting only `src/installer/sources.py` to `origin/main` fails both new cases (150 passed, 2 failed). `splitlines(keepends=True)` is the obvious narrower fix and **it does pass the newline case** — csv reassembles the quoted field from the kept terminators — but it still fails the U+2028 case, which is why the test parametrises both. `ruff check` reports the same 3 pre-existing `PLR1704` on an unmodified checkout and none in what I touched.

I did not change `parse_record_file` itself beyond one docstring line; it already accepts any iterable of strings.

AI assistance: this change was drafted with Claude Opus 5 (`claude-opus-5`). The outputs above were produced by running installer's own writer and reader locally against this branch.
